### PR TITLE
fix(#1747): Replace deprecated props in mui based components

### DIFF
--- a/src/components/Popover.js
+++ b/src/components/Popover.js
@@ -59,8 +59,7 @@ const Popover = ({ className, trigger, refExit, hide, content, ...providedProps 
       <MuiPopover
         elevation={2}
         open={isOpen}
-        onClose={handleRequestClose}
-        onExited={handleOnExit}
+        TransitionProps={{ onExited: handleOnExit, onClose: handleRequestClose }}
         anchorEl={anchorEl.current}
         anchorOrigin={anchorOriginSpecs}
         transformOrigin={transformOriginSpecs}

--- a/src/components/TablePagination.js
+++ b/src/components/TablePagination.js
@@ -98,8 +98,8 @@ function TablePagination(props) {
                 },
               }}
               rowsPerPageOptions={options.rowsPerPageOptions}
-              onChangePage={handlePageChange}
-              onChangeRowsPerPage={handleRowChange}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowChange}
             />
           </div>
         </MuiTableCell>

--- a/src/components/TableToolbar.js
+++ b/src/components/TableToolbar.js
@@ -349,7 +349,7 @@ class TableToolbar extends React.Component {
               <IconButton
                 aria-label={search}
                 data-testid={search + '-iconButton'}
-                buttonRef={el => (this.searchButton = el)}
+                ref={el => (this.searchButton = el)}
                 classes={{ root: this.getActiveIcon(classes, 'search') }}
                 disabled={options.search === 'disabled'}
                 onClick={this.handleSearchIconClick}>


### PR DESCRIPTION
- Used TransitionProps instead of the deprecated onClose and onExited Props for material-ui based Popover.

- Used onPageChange and onRowsPageChange Props instead of the deprecated onChangePage and onChangeRowsPerPage Props respectively, for material-ui based TablePagination. 

- Used ref instead of the deprecated buttonRef for material-ui based IconButton .